### PR TITLE
Expanded types to add more missing properties

### DIFF
--- a/packages/base/src/core/ISkeleton.ts
+++ b/packages/base/src/core/ISkeleton.ts
@@ -7,6 +7,45 @@ import type {Matrix} from '@pixi/math';
 /**
  * @public
  */
+ export enum BlendMode {
+    Normal,
+    Additive,
+    Multiply,
+    Screen
+}
+
+/**
+ * @public
+ */
+ export enum MixBlend {
+    setup,
+    first,
+    replace,
+    add
+}
+
+/**
+ * @public
+ */
+ export enum MixDirection {
+    mixIn,
+    mixOut
+}
+
+/**
+ * @public
+ */
+ export enum TransformMode {
+    Normal,
+    OnlyTranslation,
+    NoRotationOrReflection,
+    NoScale,
+    NoScaleOrReflection
+}
+
+/**
+ * @public
+ */
 export interface IBone {
     data: { name: string };
     matrix: Matrix;
@@ -22,6 +61,24 @@ export interface ISkin {
     setAttachment (slotIndex: number, name: string, attachment: IAttachment): void;
     getAttachment (slotIndex: number, name: string): IAttachment | null;
     attachAll (skeleton: ISkeleton, oldSkin: ISkin): void;
+}
+
+/**
+ * @public
+ */
+export interface IAnimation {
+    name: string;
+    timelines: ITimeline[];
+    duration: number;
+
+    apply (skeleton: ISkeleton, lastTime: number, time: number, loop: boolean, events: Array<Event>, alpha: number, blend: MixBlend, direction: MixDirection): void;
+}
+
+/**
+ * @public
+ */
+export interface ITimeline {
+    apply (skeleton: ISkeleton, lastTime: number, time: number, events: Array<Event>, alpha: number, blend: MixBlend, direction: MixDirection): void;
 }
 
 /**
@@ -73,6 +130,30 @@ export interface IMeshAttachment extends IVertexAttachment {
  */
 export interface ISlotData {
     index: number;
+    name: string;
+    boneData: IBoneData;
+    color: Color;
+    darkColor: Color;
+    attachmentName: string;
+    blendMode: BlendMode;
+}
+
+/**
+ * @public
+ */
+export interface IBoneData {
+    index: number;
+    name: string;
+    parent: IBoneData;
+    length: number;
+    x: number;
+    y: number;
+    rotation: number;
+    scaleX: number;
+    scaleY: number;
+    shearX: number;
+    shearY: number;
+    transformMode: TransformMode;
 }
 
 /**
@@ -139,12 +220,24 @@ export interface ISkeletonParser {
  */
 export interface ISkeletonData {
     name: string;
+    bones: IBoneData[];
+    slots: ISlotData[];
+    skins: ISkin[];
+    defaultSkin: ISkin;
+    events: IEventData[];
+    animations: IAnimation[];
     version: string;
     hash: string;
     width: number;
     height: number;
 
+    findBone(boneName: string): IBone | null;
+    findBoneIndex(boneName: string): number;
+    findSlot(slotName: string): ISlot | null;
+    findSlotIndex (slotName: string): number;
     findSkin (skinName: string): ISkin | null;
+    findEvent (eventDataName: string): IEventData | null;
+    findAnimation (animationName: string): IAnimation | null;
 }
 
 /**
@@ -164,7 +257,9 @@ export interface ITrackEntry {
  * @public
  */
 export interface IAnimationState {
-    tracks: ITrackEntry;
+    data: IAnimationStateData;
+    tracks: ITrackEntry[];
+    listeners: IAnimationStateListener[];
     timeScale: number;
 
     update(dt: number): void;
@@ -187,8 +282,12 @@ export interface IAnimationState {
  * @public
  */
 export interface IAnimationStateData {
+    skeletonData: ISkeletonData;
+    animationToMixTime: Map<number>;
     defaultMix: number;
     setMix (fromName: string, toName: string, duration: number): void;
+    setMixWith (from: Animation, to: Animation, duration: number): void;
+    getMix (from: Animation, to: Animation): number;
 }
 
 /**

--- a/packages/base/src/core/ISkeleton.ts
+++ b/packages/base/src/core/ISkeleton.ts
@@ -3,16 +3,7 @@ import type {Color, Vector2, Map} from './Utils';
 import type {TextureRegion} from './TextureRegion';
 
 import type {Matrix} from '@pixi/math';
-
-/**
- * @public
- */
- export enum BlendMode {
-    Normal,
-    Additive,
-    Multiply,
-    Screen
-}
+import {BLEND_MODES} from '@pixi/constants';
 
 /**
  * @public
@@ -135,7 +126,7 @@ export interface ISlotData {
     color: Color;
     darkColor: Color;
     attachmentName: string;
-    blendMode: BlendMode;
+    blendMode: BLEND_MODES;
 }
 
 /**


### PR DESCRIPTION
Expanded the types a little more to add some other properties I've found shared across Spine [3.7](https://github.com/EsotericSoftware/spine-runtimes/tree/3.7/spine-ts/core/src), [3.8](https://github.com/EsotericSoftware/spine-runtimes/tree/3.8/spine-ts/core/src) and [4.0](https://github.com/EsotericSoftware/spine-runtimes/tree/4.0/spine-ts/core/src).

I wouldn't normally include enums in the same file as interfaces but I couldn't identify a clear pattern for where to define them based on the rest of the code so I just put them at the top of this file. If you'd rather they were split into individual files or put into one enum file together just let me know.

Mostly new additions but there is the one fix where I accidentally typed tracks as `ITrackEntry` instead of `ITrackEntry[]` previously.