### PR TITLE
Adding Constraint Types to ISkeleton

### DIFF
--- a/packages/base/src/core/IConstraint.ts
+++ b/packages/base/src/core/IConstraint.ts
@@ -1,0 +1,109 @@
+import {IBone, IBoneData, ISlot, ISlotData} from './ISkeleton';
+
+/**
+ * @public
+ */
+export enum PositionMode {
+    Fixed, Percent
+}
+
+/**
+ * @public
+ */
+export enum RotateMode {
+    Tangent, Chain, ChainScale
+}
+
+/**
+ * @public
+ */
+export interface IConstraintData {
+    name: string;
+    order: number;
+}
+
+/**
+ * @public
+ */
+export interface IIkConstraint {
+    data: IIkConstraintData;
+    bones: IBone[];
+    target: IBone;
+    bendDirection: -1 | 0 | 1;
+    compress: boolean;
+    stretch: boolean;
+
+    /** A percentage (0-1) */
+    mix: number;
+}
+
+/**
+ * @public
+ */
+export interface IIkConstraintData extends IConstraintData {
+    bones: IBoneData[];
+    target: IBoneData;
+    bendDirection: -1 | 0 | 1;
+    compress: boolean;
+    stretch: boolean;
+    uniform: boolean;
+
+    /** A percentage (0-1) */
+    mix: number;
+}
+
+/**
+ * @public
+ */
+export interface IPathConstraint {
+    data: IPathConstraintData;
+    bones: IBone[];
+    target: ISlot;
+    position: number;
+    spacing: number;
+
+    spaces: number[];
+    positions: number[];
+    world: number[];
+    curves: number[];
+    lengths: number[];
+    segments: number[];
+}
+
+/**
+ * @public
+ */
+export interface IPathConstraintData extends IConstraintData {
+    bones: IBoneData;
+    target: ISlotData;
+    positionMode: PositionMode;
+    rotateMode: RotateMode;
+    offsetRotation: number;
+    position: number;
+    spacing: number;
+}
+
+/**
+ * @public
+ */
+export interface ITransformConstraint {
+    data: ITransformConstraintData;
+    bones: IBone[];
+    target: IBone;
+}
+
+/**
+ * @public
+ */
+export interface ITransformConstraintData extends IConstraintData {
+    bones: IBoneData[];
+    target: IBoneData;
+    offsetRotation: number;
+    offsetX: number;
+    offsetY: number;
+    offsetScaleX: number;
+    offsetScaleY: number;
+    offsetShearY: number;
+    relative: boolean;
+    local: boolean;
+}

--- a/packages/base/src/core/ISkeleton.ts
+++ b/packages/base/src/core/ISkeleton.ts
@@ -1,4 +1,5 @@
 import {AttachmentType} from './AttachmentType';
+import {IIkConstraint, IPathConstraint, ITransformConstraint} from './IConstraint';
 import type {Color, Vector2, Map} from './Utils';
 import type {TextureRegion} from './TextureRegion';
 
@@ -139,12 +140,19 @@ export interface ISkeletonParser {
  */
 export interface ISkeletonData {
     name: string;
+    ikConstraints: IIkConstraint[];
+    transformConstraints: ITransformConstraint[];
+    pathConstraints: IPathConstraint[];
     version: string;
     hash: string;
     width: number;
     height: number;
 
     findSkin (skinName: string): ISkin | null;
+
+    findIkConstraint (constraintName: string): IIkConstraint | null;
+    findTransformConstraint (constraintName: string): ITransformConstraint | null;
+    findPathConstraint (constraintName: string): IPathConstraint | null;
 }
 
 /**

--- a/packages/base/src/index.ts
+++ b/packages/base/src/index.ts
@@ -2,6 +2,7 @@
 export * from './core/AttachmentType';
 export * from './core/BinaryInput';
 export * from './core/ISkeleton';
+export * from './core/IConstraint';
 export * from './core/TextureAtlas';
 export * from './core/TextureRegion';
 export * from './core/Utils';


### PR DESCRIPTION
Added some Constraint specific types to the ISkeleton interface.

I felt the ISkeleton file itself was getting a little big so separated the constraint interfaces into their own file. If you'd rather they were all together I can put them in the ISkeleton file.

Similar to the previous PR I have declared some enums at the top of this file though I wouldn't usually put them in the same file as interfaces, just let me know if you would like these moved and where too.