### PR TITLE
Cleanup peer dependencies

### DIFF
--- a/bundles/all-3.8/rollup.config.js
+++ b/bundles/all-3.8/rollup.config.js
@@ -1,4 +1,5 @@
 const { main } = require('@pixi-spine/rollup-config/main');
+const pkg = require('./package.json');
 
 const results = main({
     globals: {
@@ -9,10 +10,13 @@ const results = main({
     },
 });
 
-// TODO: get sorted deps of all our @pixi-spine deps
-
-const umdDeps = ['@pixi/constants', '@pixi/core', '@pixi/display', '@pixi/graphics',
-    '@pixi/loaders', '@pixi/math', '@pixi/mesh-extras', '@pixi/sprite', '@pixi/utils'];
+// Find all the peer deps. Note: This assumes we have only two levels of peer deps.
+let umdDeps = [];
+const deps = Object.keys(pkg.dependencies || {});
+for (let dep of deps) {
+    const p = require(`${dep}/package.json`);
+    umdDeps = umdDeps.concat(Object.keys(p.peerDependencies || {}));
+}
 
 const license1 = 'is licensed under the MIT License.\n * http://www.opensource.org/licenses/mit-license';
 const licenseSpine = 'is licensed under SPINE-LICENSE\n * http://esotericsoftware.com/spine-runtimes-license';

--- a/bundles/all-3.8/rollup.config.js
+++ b/bundles/all-3.8/rollup.config.js
@@ -11,7 +11,7 @@ const results = main({
 
 // TODO: get sorted deps of all our @pixi-spine deps
 
-const umdDeps = ['@pixi/app', '@pixi/constants', '@pixi/core', '@pixi/display', '@pixi/graphics',
+const umdDeps = ['@pixi/constants', '@pixi/core', '@pixi/display', '@pixi/graphics',
     '@pixi/loaders', '@pixi/math', '@pixi/mesh-extras', '@pixi/sprite', '@pixi/utils'];
 
 const license1 = 'is licensed under the MIT License.\n * http://www.opensource.org/licenses/mit-license';

--- a/bundles/all-4.0/rollup.config.js
+++ b/bundles/all-4.0/rollup.config.js
@@ -1,4 +1,5 @@
 const { main } = require('@pixi-spine/rollup-config/main');
+const pkg = require('./package.json');
 
 const results = main({
     globals: {
@@ -9,10 +10,14 @@ const results = main({
     },
 });
 
-// TODO: get sorted deps of all our @pixi-spine deps
+// Find all the peer deps. Note: This assumes we have only two levels of peer deps.
+let umdDeps = [];
+const deps = Object.keys(pkg.dependencies || {});
+for (let dep of deps) {
+    const p = require(`${dep}/package.json`);
+    umdDeps = umdDeps.concat(Object.keys(p.peerDependencies || {}));
+}
 
-const umdDeps = ['@pixi/constants', '@pixi/core', '@pixi/display', '@pixi/graphics',
-    '@pixi/loaders', '@pixi/math', '@pixi/mesh-extras', '@pixi/sprite', '@pixi/utils'];
 
 const license1 = 'is licensed under the MIT License.\n * http://www.opensource.org/licenses/mit-license';
 const licenseSpine = 'is licensed under SPINE-LICENSE\n * http://esotericsoftware.com/spine-runtimes-license';

--- a/bundles/all-4.0/rollup.config.js
+++ b/bundles/all-4.0/rollup.config.js
@@ -11,7 +11,7 @@ const results = main({
 
 // TODO: get sorted deps of all our @pixi-spine deps
 
-const umdDeps = ['@pixi/app', '@pixi/constants', '@pixi/core', '@pixi/display', '@pixi/graphics',
+const umdDeps = ['@pixi/constants', '@pixi/core', '@pixi/display', '@pixi/graphics',
     '@pixi/loaders', '@pixi/math', '@pixi/mesh-extras', '@pixi/sprite', '@pixi/utils'];
 
 const license1 = 'is licensed under the MIT License.\n * http://www.opensource.org/licenses/mit-license';

--- a/bundles/all-4.1/rollup.config.js
+++ b/bundles/all-4.1/rollup.config.js
@@ -1,4 +1,5 @@
 const { main } = require('@pixi-spine/rollup-config/main');
+const pkg = require('./package.json');
 
 const results = main({
     globals: {
@@ -9,10 +10,13 @@ const results = main({
     },
 });
 
-// TODO: get sorted deps of all our @pixi-spine deps
-
-const umdDeps = ['@pixi/constants', '@pixi/core', '@pixi/display', '@pixi/graphics',
-    '@pixi/loaders', '@pixi/math', '@pixi/mesh-extras', '@pixi/sprite', '@pixi/utils'];
+// Find all the peer deps. Note: This assumes we have only two levels of peer deps.
+let umdDeps = [];
+const deps = Object.keys(pkg.dependencies || {});
+for (let dep of deps) {
+    const p = require(`${dep}/package.json`);
+    umdDeps = umdDeps.concat(Object.keys(p.peerDependencies || {}));
+}
 
 const license1 = 'is licensed under the MIT License.\n * http://www.opensource.org/licenses/mit-license';
 const licenseSpine = 'is licensed under SPINE-LICENSE\n * http://esotericsoftware.com/spine-runtimes-license';

--- a/bundles/all-4.1/rollup.config.js
+++ b/bundles/all-4.1/rollup.config.js
@@ -11,7 +11,7 @@ const results = main({
 
 // TODO: get sorted deps of all our @pixi-spine deps
 
-const umdDeps = ['@pixi/app', '@pixi/constants', '@pixi/core', '@pixi/display', '@pixi/graphics',
+const umdDeps = ['@pixi/constants', '@pixi/core', '@pixi/display', '@pixi/graphics',
     '@pixi/loaders', '@pixi/math', '@pixi/mesh-extras', '@pixi/sprite', '@pixi/utils'];
 
 const license1 = 'is licensed under the MIT License.\n * http://www.opensource.org/licenses/mit-license';

--- a/bundles/pixi-spine/rollup.config.js
+++ b/bundles/pixi-spine/rollup.config.js
@@ -13,7 +13,7 @@ const results = main({
 
 // TODO: get sorted deps of all our @pixi-spine deps
 
-const umdDeps = ['@pixi/app', '@pixi/constants', '@pixi/core', '@pixi/display', '@pixi/graphics',
+const umdDeps = ['@pixi/constants', '@pixi/core', '@pixi/display', '@pixi/graphics',
     '@pixi/loaders', '@pixi/math', '@pixi/mesh-extras', '@pixi/sprite', '@pixi/utils'];
 
 const license1 = 'is licensed under the MIT License.\n * http://www.opensource.org/licenses/mit-license';

--- a/bundles/pixi-spine/rollup.config.js
+++ b/bundles/pixi-spine/rollup.config.js
@@ -1,4 +1,5 @@
 const { main } = require('@pixi-spine/rollup-config/main');
+const pkg = require('./package.json');
 
 const results = main({
     globals: {
@@ -11,10 +12,14 @@ const results = main({
     },
 });
 
-// TODO: get sorted deps of all our @pixi-spine deps
+// Find all the peer deps. Note: This assumes we have only two levels of peer deps.
+let umdDeps = [];
+const deps = Object.keys(pkg.dependencies || {});
+for (let dep of deps) {
+    const p = require(`${dep}/package.json`);
+    umdDeps = umdDeps.concat(Object.keys(p.peerDependencies || {}));
+}
 
-const umdDeps = ['@pixi/constants', '@pixi/core', '@pixi/display', '@pixi/graphics',
-    '@pixi/loaders', '@pixi/math', '@pixi/mesh-extras', '@pixi/sprite', '@pixi/utils'];
 
 const license1 = 'is licensed under the MIT License.\n * http://www.opensource.org/licenses/mit-license';
 const licenseSpine = 'is licensed under SPINE-LICENSE\n * http://esotericsoftware.com/spine-runtimes-license';

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -15,8 +15,6 @@
     "@pixi/math": "^6.1.0",
     "@pixi/mesh": "^6.1.0",
     "@pixi/mesh-extras": "^6.1.0",
-    "@pixi/runner": "^6.1.0",
-    "@pixi/settings": "^6.1.0",
     "@pixi/sprite": "^6.1.0",
     "@pixi/utils": "^6.1.0"
   },
@@ -53,6 +51,9 @@
     "rimraf": "3.0.2",
     "rollup": "^2.53.3",
     "tslib": "~2.2.0",
-    "typescript": "~4.3.0"
+    "typescript": "~4.3.0",
+    "@pixi/runner": "^6.1.0",
+    "@pixi/settings": "^6.1.0",
+    "@pixi/extensions": "^6.1.0"
   }
 }

--- a/packages/loader-3.8/package.json
+++ b/packages/loader-3.8/package.json
@@ -8,15 +8,7 @@
   "types": "./index.d.ts",
   "namespace": "PIXI.spine",
   "peerDependencies": {
-    "@pixi/extensions": "^6.5.1",
-    "@pixi/core": "^6.1.0",
-    "@pixi/display": "^6.1.0",
     "@pixi/loaders": "^6.1.0"
-  },
-  "peerDependenciesMeta": {
-    "@pixi/extensions": {
-      "optional": true
-    }
   },
   "dependencies": {
     "@pixi-spine/base": "~3.1.0",

--- a/packages/loader-3.8/package.json
+++ b/packages/loader-3.8/package.json
@@ -8,11 +8,15 @@
   "types": "./index.d.ts",
   "namespace": "PIXI.spine",
   "peerDependencies": {
-    "@pixi/app": "^6.1.0",
+    "@pixi/extensions": "^6.5.1",
     "@pixi/core": "^6.1.0",
     "@pixi/display": "^6.1.0",
-    "@pixi/loaders": "^6.1.0",
-    "resource-loader": "~3.0.1"
+    "@pixi/loaders": "^6.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@pixi/extensions": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@pixi-spine/base": "~3.1.0",

--- a/packages/loader-4.0/package.json
+++ b/packages/loader-4.0/package.json
@@ -8,15 +8,9 @@
   "types": "./index.d.ts",
   "namespace": "PIXI.spine",
   "peerDependencies": {
-    "@pixi/extensions": "^6.5.1",
     "@pixi/core": "^6.1.0",
     "@pixi/display": "^6.1.0",
     "@pixi/loaders": "^6.1.0"
-  },
-  "peerDependenciesMeta": {
-    "@pixi/extensions": {
-      "optional": true
-    }
   },
   "dependencies": {
     "@pixi-spine/base": "~3.1.0",

--- a/packages/loader-4.0/package.json
+++ b/packages/loader-4.0/package.json
@@ -8,11 +8,15 @@
   "types": "./index.d.ts",
   "namespace": "PIXI.spine",
   "peerDependencies": {
-    "@pixi/app": "^6.1.0",
+    "@pixi/extensions": "^6.5.1",
     "@pixi/core": "^6.1.0",
     "@pixi/display": "^6.1.0",
-    "@pixi/loaders": "^6.1.0",
-    "resource-loader": "~3.0.1"
+    "@pixi/loaders": "^6.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@pixi/extensions": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@pixi-spine/base": "~3.1.0",

--- a/packages/loader-4.1/package.json
+++ b/packages/loader-4.1/package.json
@@ -8,15 +8,9 @@
   "types": "./index.d.ts",
   "namespace": "PIXI.spine",
   "peerDependencies": {
-    "@pixi/extensions": "^6.5.1",
     "@pixi/core": "^6.1.0",
     "@pixi/display": "^6.1.0",
     "@pixi/loaders": "^6.1.0"
-  },
-  "peerDependenciesMeta": {
-    "@pixi/extensions": {
-      "optional": true
-    }
   },
   "dependencies": {
     "@pixi-spine/base": "~3.1.0",

--- a/packages/loader-4.1/package.json
+++ b/packages/loader-4.1/package.json
@@ -8,11 +8,15 @@
   "types": "./index.d.ts",
   "namespace": "PIXI.spine",
   "peerDependencies": {
-    "@pixi/app": "^6.1.0",
+    "@pixi/extensions": "^6.5.1",
     "@pixi/core": "^6.1.0",
     "@pixi/display": "^6.1.0",
-    "@pixi/loaders": "^6.1.0",
-    "resource-loader": "~3.0.1"
+    "@pixi/loaders": "^6.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@pixi/extensions": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@pixi-spine/base": "~3.1.0",

--- a/packages/loader-base/package.json
+++ b/packages/loader-base/package.json
@@ -8,16 +8,9 @@
   "types": "./index.d.ts",
   "namespace": "PIXI.spine",
   "peerDependencies": {
-    "@pixi/extensions": "^6.5.1",
     "@pixi/constants": "^6.1.0",
     "@pixi/core": "^6.1.0",
-    "@pixi/display": "^6.1.0",
     "@pixi/loaders": "^6.1.0"
-  },
-  "peerDependenciesMeta": {
-    "@pixi/extensions": {
-      "optional": true
-    }
   },
   "dependencies": {
     "@pixi-spine/base": "~3.1.0"

--- a/packages/loader-base/package.json
+++ b/packages/loader-base/package.json
@@ -8,12 +8,16 @@
   "types": "./index.d.ts",
   "namespace": "PIXI.spine",
   "peerDependencies": {
-    "@pixi/app": "^6.1.0",
+    "@pixi/extensions": "^6.5.1",
     "@pixi/constants": "^6.1.0",
     "@pixi/core": "^6.1.0",
     "@pixi/display": "^6.1.0",
-    "@pixi/loaders": "^6.1.0",
-    "resource-loader": "~3.0.1"
+    "@pixi/loaders": "^6.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@pixi/extensions": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@pixi-spine/base": "~3.1.0"


### PR DESCRIPTION
- Loader packages relied on `@pixi/app` and `resource-loader` which were not used.
- Added `@pixi/extensions` to be compatible with 6.5.1
  - Added a `peerDependenciesMeta` to make `@pixi/extensions` optional since is not needed before 6.5.1
  
  
 ---
 
 After an `npm install` gave me errors on my project that doesn't rely on app, I investigated and found that neither `@pixi/app` nor `resource-loader` were being used in the code.
 I also added the optional new peerDep of `@pixi/extensions` to be compatible with `@pixi/core` version 6.5.1