### PR TITLE
chore: Add "exports" to package.json

### DIFF
--- a/bundles/all-3.8/package.json
+++ b/bundles/all-3.8/package.json
@@ -6,6 +6,18 @@
   "module": "lib/all-3.8.es.js",
   "bundle": "dist/pixi-spine-3.8.umd.js",
   "types": "./index.d.ts",
+  "exports": {
+		".": {
+			"import": {
+				"types": "./index.d.ts",
+				"default": "./lib/all-3.8.es.js"
+			},
+			"require": {
+				"types": "./index.d.ts",
+				"default": "./lib/all-3.8.js"
+			}
+		}
+	},
   "namespace": "PIXI.spine",
   "dependencies": {
     "@pixi-spine/base": "~3.1.0",

--- a/bundles/all-4.0/package.json
+++ b/bundles/all-4.0/package.json
@@ -6,6 +6,18 @@
   "module": "lib/all-4.0.es.js",
   "bundle": "dist/pixi-spine-4.0.umd.js",
   "types": "./index.d.ts",
+  "exports": {
+		".": {
+			"import": {
+				"types": "./index.d.ts",
+				"default": "./lib/all-4.0.es.js"
+			},
+			"require": {
+				"types": "./index.d.ts",
+				"default": "./lib/all-4.0.js"
+			}
+		}
+	},
   "namespace": "PIXI.spine",
   "dependencies": {
     "@pixi-spine/base": "~3.1.0",

--- a/bundles/all-4.1/package.json
+++ b/bundles/all-4.1/package.json
@@ -6,6 +6,18 @@
   "module": "lib/all-4.1.es.js",
   "bundle": "dist/pixi-spine-4.1.umd.js",
   "types": "./index.d.ts",
+  "exports": {
+		".": {
+			"import": {
+				"types": "./index.d.ts",
+				"default": "./lib/all-4.1.es.js"
+			},
+			"require": {
+				"types": "./index.d.ts",
+				"default": "./lib/all-4.1.js"
+			}
+		}
+	},
   "namespace": "PIXI.spine",
   "dependencies": {
     "@pixi-spine/base": "~3.1.0",

--- a/bundles/pixi-spine/package.json
+++ b/bundles/pixi-spine/package.json
@@ -6,6 +6,18 @@
   "module": "lib/all.es.js",
   "bundle": "dist/pixi-spine.umd.js",
   "types": "./index.d.ts",
+  "exports": {
+		".": {
+			"import": {
+				"types": "./index.d.ts",
+				"default": "./lib/all.es.js"
+			},
+			"require": {
+				"types": "./index.d.ts",
+				"default": "./lib/all.js"
+			}
+		}
+	},
   "namespace": "PIXI.spine",
   "dependencies": {
     "@pixi-spine/base": "~3.1.0",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -7,6 +7,18 @@
   "bundle": "dist/base.js",
   "namespace": "PIXI.spine",
   "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./lib/base.es.js"
+      },
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./lib/base.js"
+      }
+    }
+  },
   "peerDependencies": {
     "@pixi/constants": "^6.1.0",
     "@pixi/core": "^6.1.0",

--- a/packages/loader-3.8/package.json
+++ b/packages/loader-3.8/package.json
@@ -6,6 +6,18 @@
   "module": "lib/loader-3.8.es.js",
   "bundle": "dist/loader-3.8.js",
   "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./lib/loader-3.8.es.js"
+      },
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./lib/loader-3.8.js"
+      }
+    }
+  },
   "namespace": "PIXI.spine",
   "peerDependencies": {
     "@pixi/app": "^6.1.0",

--- a/packages/loader-4.0/package.json
+++ b/packages/loader-4.0/package.json
@@ -6,6 +6,18 @@
   "module": "lib/loader-4.0.es.js",
   "bundle": "dist/loader-4.0.js",
   "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./lib/loader-4.0.es.js"
+      },
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./lib/loader-4.0.js"
+      }
+    }
+  },
   "namespace": "PIXI.spine",
   "peerDependencies": {
     "@pixi/app": "^6.1.0",

--- a/packages/loader-4.1/package.json
+++ b/packages/loader-4.1/package.json
@@ -6,6 +6,18 @@
   "module": "lib/loader-4.1.es.js",
   "bundle": "dist/loader-4.1.js",
   "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./lib/loader-4.1.es.js"
+      },
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./lib/loader-4.1.js"
+      }
+    }
+  },
   "namespace": "PIXI.spine",
   "peerDependencies": {
     "@pixi/app": "^6.1.0",

--- a/packages/loader-base/package.json
+++ b/packages/loader-base/package.json
@@ -6,6 +6,18 @@
   "module": "lib/loader-base.es.js",
   "bundle": "dist/loader-base.js",
   "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./lib/loader-base.es.js"
+      },
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./lib/loader-base.js"
+      }
+    }
+  },
   "namespace": "PIXI.spine",
   "peerDependencies": {
     "@pixi/app": "^6.1.0",

--- a/packages/loader-uni/package.json
+++ b/packages/loader-uni/package.json
@@ -4,7 +4,20 @@
   "description": "Pixi integration with EsotericSoftware Spine, big, contains all runtimes",
   "main": "lib/loader-uni.js",
   "module": "lib/loader-uni.es.js",
+  "bundle": "dist/loader-uni.js",
   "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./lib/loader-uni.es.js"
+      },
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./lib/loader-uni.js"
+      }
+    }
+  },
   "namespace": "PIXI.spine",
   "peerDependencies": {
     "@pixi/loaders": "^6.1.0"

--- a/packages/runtime-3.7/package.json
+++ b/packages/runtime-3.7/package.json
@@ -7,6 +7,18 @@
   "bundle": "dist/runtime-3.7.js",
   "namespace": "PIXI.spine37",
   "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./lib/runtime-3.7.es.js"
+      },
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./lib/runtime-3.7.js"
+      }
+    }
+  },
   "peerDependencies": {
     "@pixi/constants": "^6.1.0",
     "@pixi/math": "^6.1.0"

--- a/packages/runtime-3.8/package.json
+++ b/packages/runtime-3.8/package.json
@@ -7,6 +7,18 @@
 	"bundle": "dist/runtime-3.8.js",
 	"namespace": "PIXI.spine38",
 	"types": "./index.d.ts",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./index.d.ts",
+				"default": "./lib/runtime-3.8.es.js"
+			},
+			"require": {
+				"types": "./index.d.ts",
+				"default": "./lib/runtime-3.8.js"
+			}
+		}
+	},
 	"peerDependencies": {
 		"@pixi/constants": "^6.1.0",
 		"@pixi/math": "^6.1.0"

--- a/packages/runtime-4.0/package.json
+++ b/packages/runtime-4.0/package.json
@@ -7,6 +7,18 @@
   "bundle": "dist/runtime-4.0.js",
   "namespace": "PIXI.spine40",
   "types": "./index.d.ts",
+  "exports": {
+		".": {
+			"import": {
+				"types": "./index.d.ts",
+				"default": "./lib/runtime-4.0.es.js"
+			},
+			"require": {
+				"types": "./index.d.ts",
+				"default": "./lib/runtime-4.0.js"
+			}
+		}
+	},
   "peerDependencies": {
     "@pixi/constants": "^6.1.0",
     "@pixi/math": "^6.1.0"

--- a/packages/runtime-4.1/package.json
+++ b/packages/runtime-4.1/package.json
@@ -7,6 +7,18 @@
   "bundle": "dist/runtime-4.1.js",
   "namespace": "PIXI.spine41",
   "types": "./index.d.ts",
+  "exports": {
+		".": {
+			"import": {
+				"types": "./index.d.ts",
+				"default": "./lib/runtime-4.1.es.js"
+			},
+			"require": {
+				"types": "./index.d.ts",
+				"default": "./lib/runtime-4.1.js"
+			}
+		}
+	},
   "peerDependencies": {
     "@pixi/constants": "^6.1.0",
     "@pixi/math": "^6.1.0"


### PR DESCRIPTION
Fixes for #451

**The motivation of this change [copied from corresponding pixi.js [PR](https://github.com/pixijs/pixijs/pull/8371)]:**
This CR adjusts the package.json to make PIXI easier to use in an ESM environment with TypeScript.

TypeScript 4.7 introduces official (albeit beta) support for ESM in TypeScript. In connection with modern bundling tools such as Vite, it presents an exciting opportunity for front-end development. Unfortunately, the current version of PIXI packages do not behave properly in an ESM environment due to adjustments in how TypeScript resolves packages and types.

To be more specific, when running TS in ESM mode against the current version of PIXI, it resolves the code to the CJS bundle and the types to a non-existent index file in the CJS directory. To get it to correctly resolve both the types and the entrypoint, the package.json needs to include an "exports" key that specifies both types and entrypoint for ESM and CJS.

For more details on this feature, see [they TypeScript 4.7 release notes](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing) or [the node.js documentation](https://nodejs.org/api/packages.html#packages_exports). Additionally, for fallback reasons, it's recommend to explicitly include the "types" field which specifies exactly where the types are located in the package.