### PR TITLE
strict check for currentMeshId

### DIFF
--- a/packages/base/src/SpineBase.ts
+++ b/packages/base/src/SpineBase.ts
@@ -339,7 +339,7 @@ export abstract class SpineBase<Skeleton extends ISkeleton,
                     }
 
                     const id = (attachment as IVertexAttachment).id;
-                    if (!slot.currentMeshId || slot.currentMeshId !== id) {
+                    if (slot.currentMeshId === undefined || slot.currentMeshId !== id) {
                         let meshId = id;
                         if (slot.currentMesh) {
                             slot.currentMesh.visible = false;


### PR DESCRIPTION
As we are have strict reset for `slot.currentMeshId = undefined;` and 
`id = VertexAttachment.nextID++;` for runtime 4.0 or 4.1  and  `id = (VertexAttachment.nextID++ & 65535) << 11;` for runtime 3.7 or 3.8 possible to be 0 not strict check `!slot.currentMeshId` can cause override mesh for already existing mesh and follow to override `slot.currentMesh` with undefined value and cause runtime error
<img width="1088" alt="Screenshot 2022-09-07 at 17 51 08" src="https://user-images.githubusercontent.com/1476477/188912492-7ae2b725-e45d-4790-850d-c52a608cbb3d.png">
<img width="1187" alt="Screenshot 2022-09-07 at 18 05 07" src="https://user-images.githubusercontent.com/1476477/188912855-ee43d84e-87c7-4b4a-bd8f-693421fa1202.png">
