### PR TITLE
Make Spine configurable with custom Sprite and Mesh constructors

### DIFF
--- a/packages/base/src/SpineBase.ts
+++ b/packages/base/src/SpineBase.ts
@@ -109,7 +109,7 @@ export abstract class SpineBase<Skeleton extends ISkeleton,
 
     abstract createSkeleton(spineData: ISkeletonData);
 
-    constructor(spineData: SkeletonData, SpriteCtor?: SpineSpriteConstructor, MeshCtor?: SpineMeshConstructor) {
+    constructor(spineData: SkeletonData, ctors?: { SpriteCtor?: SpineSpriteConstructor, MeshCtor?: SpineMeshConstructor }) {
         super();
 
         if (!spineData) {
@@ -120,8 +120,8 @@ export abstract class SpineBase<Skeleton extends ISkeleton,
             throw new Error('spineData param cant be string. Please use spine.Spine.fromAtlas("YOUR_RESOURCE_NAME") from now on.');
         }
 
-        this.SpriteCtor = SpriteCtor || SpineSprite;
-        this.MeshCtor = MeshCtor || SpineMesh;
+        this.SpriteCtor = ctors?.SpriteCtor || SpineSprite;
+        this.MeshCtor = ctors?.MeshCtor || SpineMesh;
 
         /**
          * The spineData object


### PR DESCRIPTION
This change can allow the user to make their Spine Sprite and Mesh anything they want.
It was the simplest way I could think of to add illumination to Spine characters.

Here is how the spine animation instantiation changes:
```ts
const illuminatedAnimation = new Spine(
        spineSkeletonData,
        SpineIlluminatedSprite,
        SpineIlluminatedMesh,
  );
```

Where `SpineIlluminatedSprite` is a custom class that satisfy the `SpineSprite` property requirements:

```ts
class SpineIlluminatedSprite extends IlluminatedSprite {
  region?: TextureRegion = null;
  attachment?: IAttachment = null;
  spineAnimation?: Spine = null;

  constructor(texture: Texture) {
    // some initialization stuff here
  }
}
```


## Problems
1. This requirement is not enforced by the typescript syntax, I wonder what is the best way to achieve this. The main issue is that my custom spine component has to be an extension of both a custom sprite and a spine sprite to work!
The best solution, in my opinion, would be change the `SpineSprite` to use composition and include a sprite property instead of inheriting from the Sprite class. This would also reduce the amount of de-opts in the pixi rendering pipeline.
1. This change is made on `v3` and not `v4` because our project can only use `v3` at the moment! What is the right branch on which to submit this change?