### PR TITLE
Fixed issue with new @pixi/color

### DIFF
--- a/packages/base/src/SpineBase.ts
+++ b/packages/base/src/SpineBase.ts
@@ -11,8 +11,6 @@ import { Graphics } from '@pixi/graphics';
 import { settings } from './settings';
 import type { ISpineDebugRenderer } from './SpineDebugRenderer';
 
-const tempRgb = [0, 0, 0];
-
 /**
  * @public
  */
@@ -322,10 +320,11 @@ export abstract class SpineBase<
                         // YAY! double - tint!
                         spriteColor = slot.currentSprite.color;
                     } else {
-                        tempRgb[0] = light[0] * slot.color.r * attColor.r;
-                        tempRgb[1] = light[1] * slot.color.g * attColor.g;
-                        tempRgb[2] = light[2] * slot.color.b * attColor.b;
-                        slot.currentSprite.tint = utils.rgb2hex(tempRgb);
+                        slot.currentSprite.tint = utils.rgb2hex([
+                            light[0] * slot.color.r * attColor.r,
+                            light[1] * slot.color.g * attColor.g,
+                            light[2] * slot.color.b * attColor.b
+                        ]);
                     }
                     slot.currentSprite.blendMode = slot.blendMode;
                     break;
@@ -380,10 +379,11 @@ export abstract class SpineBase<
                         // pixi-heaven
                         spriteColor = slot.currentMesh.color;
                     } else {
-                        tempRgb[0] = light[0] * slot.color.r * attColor.r;
-                        tempRgb[1] = light[1] * slot.color.g * attColor.g;
-                        tempRgb[2] = light[2] * slot.color.b * attColor.b;
-                        slot.currentMesh.tint = utils.rgb2hex(tempRgb);
+                        slot.currentMesh.tint = utils.rgb2hex([
+                            light[0] * slot.color.r * attColor.r,
+                            light[1] * slot.color.g * attColor.g,
+                            light[2] * slot.color.b * attColor.b
+                        ]);
                     }
                     slot.currentMesh.blendMode = slot.blendMode;
                     if (!slot.hackRegion) {


### PR DESCRIPTION
Fixed https://github.com/pixijs/pixijs/issues/9277 

The issue here is that we pass RGB color (`tempRgb` array) to `utils.rgb2hex` as a reference. When we change RGB color it also changes in the shared Color class but doesn't recalculate the number. 
Code line related to this issue;
https://github.com/pixijs/pixijs/blob/03d68ec26c786c7cb730392603340de319393db6/packages/color/src/Color.ts#L187