### PR TITLE
Bug: make atlas loader use absolute paths

### DIFF
--- a/packages/loader-base/src/atlasLoader.ts
+++ b/packages/loader-base/src/atlasLoader.ts
@@ -96,9 +96,10 @@ const spineTextureAtlasLoader: AssetExtension<RawAtlas | TextureAtlas, ISpineMet
  * @public
  */
 export const makeSpineTextureAtlasLoaderFunctionFromPixiLoaderObject = (loader: Loader, atlasBasePath: string, imageMetadata: any) => {
+    const isAbsolute = atlasBasePath.startsWith("/");
     return async (pageName: string, textureLoadedCallback: (tex: BaseTexture) => any): Promise<void> => {
-        const url = utils.path.join(...atlasBasePath.split(utils.path.sep), pageName);
-
+        let url = utils.path.join(...atlasBasePath.split(utils.path.sep), pageName);
+        if (isAbsolute) url = `/${url}`;
         const texture = await loader.load<Texture>({ src: url, data: imageMetadata });
 
         textureLoadedCallback(texture.baseTexture);


### PR DESCRIPTION
Hi,
We are getting an issue, where if we use absolute paths for an atlas it tries to load textures from the incorrect url. I narrowed it down to it not loading textures using an absolute path.

There is some discussion about it in this thread, #493