### PR TITLE
fix: add getLoader method to SpineLoader, export atlas and spine loaders

### DIFF
--- a/packages/loader-base/src/SpineLoaderAbstract.ts
+++ b/packages/loader-base/src/SpineLoaderAbstract.ts
@@ -3,8 +3,15 @@ import { AssetExtension, checkExtension, LoadAsset, Loader, LoaderParserPriority
 import { BaseTexture, extensions, ExtensionType, settings, Texture, utils } from '@pixi/core';
 import { makeSpineTextureAtlasLoaderFunctionFromPixiLoaderObject } from './atlasLoader';
 
-type SPINEJSON = any;
-type SPINEBINARY = ArrayBuffer;
+/**
+ * @public
+ */
+export type SPINEJSON = any;
+
+/**
+ * @public
+ */
+export type SPINEBINARY = ArrayBuffer;
 
 function isJson(resource: unknown): resource is SPINEJSON {
     return resource.hasOwnProperty('bones');
@@ -27,10 +34,11 @@ export abstract class SpineLoaderAbstract<SKD extends ISkeletonData> {
 
     abstract parseData(parser: ISkeletonParser, atlas: TextureAtlas, dataToParse: any): ISpineResource<SKD>;
 
-    public installLoader(): any {
+    public getLoader(): AssetExtension<SPINEJSON | SPINEBINARY | ISpineResource<SKD>, ISpineMetadata> {
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const spineAdapter = this;
-        const spineLoaderExtension: AssetExtension<SPINEJSON | SPINEBINARY | ISpineResource<SKD>, ISpineMetadata> = {
+        
+        return {
             extension: ExtensionType.Asset,
 
             loader: {
@@ -141,6 +149,10 @@ export abstract class SpineLoaderAbstract<SKD extends ISkeletonData> {
                 // },
             },
         } as AssetExtension<SPINEJSON | SPINEBINARY | ISpineResource<SKD>, ISpineMetadata>;
+    }
+
+    public installLoader(): any {
+        const spineLoaderExtension = this.getLoader();
 
         extensions.add(spineLoaderExtension);
 

--- a/packages/loader-base/src/atlasLoader.ts
+++ b/packages/loader-base/src/atlasLoader.ts
@@ -3,9 +3,17 @@ import { type AssetExtension, LoaderParserPriority, LoadAsset, Loader, checkExte
 import { BaseTexture, extensions, ExtensionType, settings, Texture, utils } from '@pixi/core';
 import type { ISpineMetadata } from './SpineLoaderAbstract';
 
-type RawAtlas = string;
+/**
+ * Type of atlas file content.
+ * @public
+ */
+export type RawAtlas = string;
 
-const spineTextureAtlasLoader: AssetExtension<RawAtlas | TextureAtlas, ISpineMetadata> = {
+/**
+ * This variable is used loader extension for atlas files loading.
+ * @public 
+ */
+export const spineTextureAtlasLoader: AssetExtension<RawAtlas | TextureAtlas, ISpineMetadata> = {
     extension: ExtensionType.Asset,
 
     // cache: {

--- a/packages/loader-uni/src/index.ts
+++ b/packages/loader-uni/src/index.ts
@@ -3,6 +3,7 @@
 /// <reference path="../global.d.ts" />
 import '@pixi-spine/loader-base'; // Side effect install atlas loader
 import { SpineLoader } from './SpineLoader';
+export { SpineLoader };
 export * from './Spine';
 export * from './versions';
 


### PR DESCRIPTION
Solve issue https://github.com/pixijs/spine/issues/522

Add ability to use `pixi-spine` with `pixi.js-legacy` by loaders exporting, so you can register them in correct context

```
import * as PIXI from "pixi.js-legacy";
import { SpineLoader } from '@pixi-spine/loader-uni';
import { spineTextureAtlasLoader } from '@pixi-spine/loader-base';

PIXI.extensions.add(spineTextureAtlasLoader);
PIXI.extensions.add(new SpineLoader().getLoader());
```
