### PR TITLE
add setSkin method to ISkeleton interface

### DIFF
--- a/packages/base/src/core/ISkeleton.ts
+++ b/packages/base/src/core/ISkeleton.ts
@@ -199,6 +199,7 @@ export interface ISkeleton<SkeletonData extends ISkeletonData = ISkeletonData, B
     findSlot(slotName: string): Slot;
     findBoneIndex(boneName: string): number;
     findSlotIndex(slotName: string): number;
+    setSkin(newSkin: Skin | null): void;
     setSkinByName(skinName: string): void;
     setAttachment(slotName: string, attachmentName: string): void;
     getBounds(offset: Vector2, size: Vector2, temp: Array<number>): void;


### PR DESCRIPTION
Add `setSkin` method to `ISkeleton` interface, this method is already implemented by all implementations.

This allows for consumers to set skin to `null`, as recommended by the [Changing Skins guide](https://github.com/pixijs/spine/blob/master/examples/change_skin.md).

Closes https://github.com/pixijs/spine/issues/526