### PR TITLE
change utils.rgb2hex to Color.shared.setValue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2878,6 +2878,21 @@
         "@types/css-font-loading-module": "^0.0.7"
       }
     },
+    "node_modules/@pixi/color": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.3.2.tgz",
+      "integrity": "sha512-jur5PvdOtUBEUTjmPudW5qdQq6yYGlVGsi3HyhasJw14bN+GKJwiCKgIsyrsiNL5HBUXmje4ICwQohf6BqKqxA==",
+      "peer": true,
+      "dependencies": {
+        "@pixi/colord": "^2.9.6"
+      }
+    },
+    "node_modules/@pixi/colord": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
+      "peer": true
+    },
     "node_modules/@pixi/constants": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.1.0.tgz",
@@ -13648,6 +13663,7 @@
         "@pixi-spine/rollup-config": "*"
       },
       "peerDependencies": {
+        "@pixi/color": "^7.0.0",
         "@pixi/core": "^7.0.0",
         "@pixi/display": "^7.0.0",
         "@pixi/graphics": "^7.0.0",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -24,7 +24,8 @@
     "@pixi/graphics": "^7.0.0",
     "@pixi/mesh": "^7.0.0",
     "@pixi/mesh-extras": "^7.0.0",
-    "@pixi/sprite": "^7.0.0"
+    "@pixi/sprite": "^7.0.0",
+    "@pixi/color": "^7.0.0"
   },
   "scripts": {
     "build": "run-p build:*",

--- a/packages/base/src/SpineBase.ts
+++ b/packages/base/src/SpineBase.ts
@@ -10,6 +10,7 @@ import { SimpleMesh } from '@pixi/mesh-extras';
 import { Graphics } from '@pixi/graphics';
 import { settings } from './settings';
 import type { ISpineDebugRenderer } from './SpineDebugRenderer';
+import { Color } from '@pixi/color';
 
 const tempRgb = [0, 0, 0];
 
@@ -200,7 +201,7 @@ export abstract class SpineBase<
      * @default 0xFFFFFF
      */
     get tint(): number {
-        return utils.rgb2hex(this.tintRgb as any);
+        return Color.shared.setValue(Array.from(this.tintRgb)).toNumber();
     }
 
     set tint(value: number) {
@@ -325,7 +326,7 @@ export abstract class SpineBase<
                         tempRgb[0] = light[0] * slot.color.r * attColor.r;
                         tempRgb[1] = light[1] * slot.color.g * attColor.g;
                         tempRgb[2] = light[2] * slot.color.b * attColor.b;
-                        slot.currentSprite.tint = utils.rgb2hex(tempRgb);
+                        slot.currentSprite.tint = Color.shared.setValue(tempRgb).toNumber();
                     }
                     slot.currentSprite.blendMode = slot.blendMode;
                     break;
@@ -383,7 +384,7 @@ export abstract class SpineBase<
                         tempRgb[0] = light[0] * slot.color.r * attColor.r;
                         tempRgb[1] = light[1] * slot.color.g * attColor.g;
                         tempRgb[2] = light[2] * slot.color.b * attColor.b;
-                        slot.currentMesh.tint = utils.rgb2hex(tempRgb);
+                        slot.currentMesh.tint = Color.shared.setValue(tempRgb).toNumber();
                     }
                     slot.currentMesh.blendMode = slot.blendMode;
                     if (!slot.hackRegion) {


### PR DESCRIPTION
Regarding this Issue https://github.com/pixijs/spine/issues/515


Due to the deprecation of `utils.rgb2hex`, I have made the change to `Color.shared.setValue`.

![image](https://github.com/pixijs/spine/assets/11013287/1b7e565f-cd43-4c23-accd-435ad8cb214f)
