### PR TITLE
Added name to spineTextureAtlasLoader

### DIFF
--- a/packages/loader-base/src/atlasLoader.ts
+++ b/packages/loader-base/src/atlasLoader.ts
@@ -14,6 +14,7 @@ const spineTextureAtlasLoader: AssetExtension<RawAtlas | TextureAtlas, ISpineMet
     // },
 
     loader: {
+        name: "loadAtlas",
         extension: {
             type: ExtensionType.LoadParser,
             priority: LoaderParserPriority.Normal,


### PR DESCRIPTION
Added missing parser name so it can be used with Asset loader 
`loadParser: 'loadAtlas'`